### PR TITLE
Update mcp9808_simpletest.py

### DIFF
--- a/examples/mcp9808_simpletest.py
+++ b/examples/mcp9808_simpletest.py
@@ -10,7 +10,7 @@ mcp = adafruit_mcp9808.MCP9808(i2c_bus)
 
 # To initialise using a specified address:
 # Necessary when, for example, connecting A0 to VDD to make address=0x19
-# mcp = adafruit_mcp9808.MCP9808(i2c_bus, 0x19)
+# mcp = adafruit_mcp9808.MCP9808(i2c_bus, address=0x19)
 
 
 

--- a/examples/mcp9808_simpletest.py
+++ b/examples/mcp9808_simpletest.py
@@ -5,7 +5,11 @@ import adafruit_mcp9808
 
 # This example shows how to get the temperature from a MCP9808 board
 i2c_bus = busio.I2C(board.SCL, board.SDA)
-mcp = adafruit_mcp9808.MCP9808(i2c_bus)
+mcp = adafruit_mcp9808.MCP9808(i2c_bus) # Object has only one parameter specified so default address (0x18) is used
+
+# If the address of the module has been changed (eg by connecting A0 to VDD making address 0x19)
+# mcp = adafruit_mcp9808.MCP9808(i2c_bus,0x19) # Object now has two parameters - the new address 0x19 being the second one
+
 
 while True:
     tempC = mcp.temperature

--- a/examples/mcp9808_simpletest.py
+++ b/examples/mcp9808_simpletest.py
@@ -3,12 +3,14 @@ import board
 import busio
 import adafruit_mcp9808
 
-# This example shows how to get the temperature from a MCP9808 board
+# This example shows how to get the temperature from a MCP9808 board.
+# The object has only one parameter specified so default address (0x18) is used
 i2c_bus = busio.I2C(board.SCL, board.SDA)
-mcp = adafruit_mcp9808.MCP9808(i2c_bus) # Object has only one parameter specified so default address (0x18) is used
+mcp = adafruit_mcp9808.MCP9808(i2c_bus)
 
-# If the address of the module has been changed (eg by connecting A0 to VDD making address 0x19)
-# mcp = adafruit_mcp9808.MCP9808(i2c_bus,0x19) # Object now has two parameters - the new address 0x19 being the second one
+# This second example if for when the address of the module has been changed (eg by connecting A0 to VDD making address=0x19)
+# mcp = adafruit_mcp9808.MCP9808(i2c_bus,0x19)
+# Object now has two parameters - the new address (0x19) being the second one
 
 
 while True:

--- a/examples/mcp9808_simpletest.py
+++ b/examples/mcp9808_simpletest.py
@@ -3,14 +3,15 @@ import board
 import busio
 import adafruit_mcp9808
 
-# This example shows how to get the temperature from a MCP9808 board.
-# The object has only one parameter specified so default address (0x18) is used
 i2c_bus = busio.I2C(board.SCL, board.SDA)
+
+# To initialise using the default address:
 mcp = adafruit_mcp9808.MCP9808(i2c_bus)
 
-# This second example if for when the address of the module has been changed (eg by connecting A0 to VDD making address=0x19)
-# mcp = adafruit_mcp9808.MCP9808(i2c_bus,0x19)
-# Object now has two parameters - the new address (0x19) being the second one
+# To initialise using a specified address:
+# Necessary when, for example, connecting A0 to VDD to make address=0x19
+# mcp = adafruit_mcp9808.MCP9808(i2c_bus, 0x19)
+
 
 
 while True:


### PR DESCRIPTION
The original example code did not show the syntax for setting up a module with anything other than the default address. While this information is to be found in the object definition document, a simple amendment to the sample code gives the default and an amended address example.